### PR TITLE
WL-3318 : Remove irrelevant bits of tutorial & use English spellings

### DIFF
--- a/help-component/src/java/org/sakaiproject/component/app/help/TutorialEntityProviderImpl.java
+++ b/help-component/src/java/org/sakaiproject/component/app/help/TutorialEntityProviderImpl.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 public class TutorialEntityProviderImpl implements TutorialEntityProvider, AutoRegisterEntityProvider, RESTful{
 
-	public static final String SITE_NAME = "site.name";
+	public static final String SITE_NAME = "ui.service";
 	public static final String SAKAI = "Sakai";
 	protected final Log log = LogFactory.getLog(getClass());
 	private ResourceLoader msgs = new ResourceLoader("TutorialMessages");


### PR DESCRIPTION
'Sakai' is mentioned in the tutorial because the Java default is 'Sakai' if there is no 'site.name' property in the config.  I've made it get the 'ui.service' property instead which is 'WebLearn' (and then we can push it back).
